### PR TITLE
Fix splat operator with associative arrays

### DIFF
--- a/resources/views/forms/icon-picker.blade.php
+++ b/resources/views/forms/icon-picker.blade.php
@@ -1,6 +1,5 @@
 <div {{ $attributes->merge([
     'class' => "filament-icon-picker filament-icon-picker-{$getLayout()}",
-    ...$getColumnsConfig()
-]) }}>
+])->merge($getColumnsConfig()) }}>
 	@include('forms::components.select')
 </div>


### PR DESCRIPTION
Associative arrays are not compatible with the splat operator. This PR simply uses the magic of the merge method to merge the columns config into the attributes.