### PR TITLE
Fix incompatible declaration

### DIFF
--- a/src/Forms/IconPicker.php
+++ b/src/Forms/IconPicker.php
@@ -162,7 +162,7 @@ class IconPicker extends Select
         return $results;
     }
 
-    public function relationship(string|Closure|null $name = null, string|Closure|null $titleAttribute = null, ?Closure $modifyQueryUsing = null): static
+    public function relationship(string|Closure|null $name = null, string|Closure|null $titleAttribute = null, ?Closure $modifyQueryUsing = null, bool $ignoreRecord = false): static
     {
         throw new \BadMethodCallException('Method not allowed.');
     }


### PR DESCRIPTION
Fixed next issue:
```
Declaration of Guava\FilamentIconPicker\Forms\IconPicker::relationship(Closure|string|null $name = null, Closure|string|null $titleAttribute = null, ?Closure $modifyQueryUsing = null): static must be compatible with Filament\Forms\Components\Select::relationship(Closure|string|null $name = null, Closure|string|null $titleAttribute = null, ?Closure $modifyQueryUsing = null, bool $ignoreRecord = false): static
```