### PR TITLE
Feature: Add caching for generating the icons array

### DIFF
--- a/src/Forms/IconPicker.php
+++ b/src/Forms/IconPicker.php
@@ -241,9 +241,10 @@ class IconPicker extends Select
             });
 
 
+        $allowedSetsHash = md5(serialize($sets));
         $allowedHash = md5(serialize($allowedIcons));
         $disallowedHash = md5(serialize($disallowedIcons));
-        $iconsKey = "icon-picker.fields.icons.{$iconsHash}.{$allowedHash}.{$disallowedHash}.{$this->getStatePath()}";
+        $iconsKey = "icon-picker.fields.icons.{$iconsHash}.{$allowedSetsHash}.{$allowedHash}.{$disallowedHash}.{$this->getStatePath()}";
         
         $icons = $this->tryCache($iconsKey, function() use($sets, $allowedIcons, $disallowedIcons) {
             $icons = [];

--- a/src/Forms/IconPicker.php
+++ b/src/Forms/IconPicker.php
@@ -273,6 +273,8 @@ class IconPicker extends Select
                     }
                 }
             }
+
+            return $icons;
         });
 
         return collect($icons);


### PR DESCRIPTION
This PR makes it so that instead of iterating over files each time we load icons, it loads them once and uses a cached version on subsequent calls.

It should improve performance when using large/multiple icon sets.

Closes #35 