### PR TITLE
Feature: add preload support

### DIFF
--- a/src/Forms/IconPicker.php
+++ b/src/Forms/IconPicker.php
@@ -166,7 +166,8 @@ class IconPicker extends Select
     /**
      * Enact the preload logic (if, and only if, the user wants to preload the icons)
      */
-    protected function doPreload(): void {
+    protected function doPreload(): void
+    {
         if (!$this->isPreloaded()) {
             return;
         }
@@ -197,6 +198,7 @@ class IconPicker extends Select
         $this->doPreload();
         return parent::getOptions();
     }
+
     public function relationship(string|Closure|null $name = null, string|Closure|null $titleAttribute = null, ?Closure $modifyQueryUsing = null, bool $ignoreRecord = false): static
     {
         throw new \BadMethodCallException('Method not allowed.');

--- a/src/Forms/IconPicker.php
+++ b/src/Forms/IconPicker.php
@@ -163,6 +163,40 @@ class IconPicker extends Select
         return $results;
     }
 
+    /**
+     * Enact the preload logic (if, and only if, the user wants to preload the icons)
+     */
+    protected function doPreload(): void {
+        if (!$this->isPreloaded()) {
+            return;
+        }
+
+        // To actually preload the icons, we trigger a search on the empty string.
+        // `str_contains` will return true for any haystack if the needle is the empty string.
+        // This is exactly how we know we get all the icons AND respect the user-land
+        // configuration applied to this field instance.
+        $options = $this->getSearchResults('');
+
+        // To avoid recursively and needlessly loading the icons each time
+        // anything requests the options or uses the `doPreload` method,
+        // we set the `preload` option to false right before setting the
+        // resolved/computed icons.
+        $this->preload(false);
+
+        // We delegate back to the parent's `options` method as a setter
+        // to keep our own as a throwing-method in user-land.
+        // This sets the icons on the back-end and front-end.
+        // It also make it work as soon as the component is mounted,
+        // which means there's no need for user interaction to get the
+        // full list of options loaded directly.
+        parent::options($options);
+    }
+
+    public function getOptions(): array
+    {
+        $this->doPreload();
+        return parent::getOptions();
+    }
     public function relationship(string|Closure|null $name = null, string|Closure|null $titleAttribute = null, ?Closure $modifyQueryUsing = null, bool $ignoreRecord = false): static
     {
         throw new \BadMethodCallException('Method not allowed.');


### PR DESCRIPTION
With this PR, users can use `->preload(/*true*/)` to preload all icons. This makes it so that all icons appear when the select is opened.

Closes #34 