### PR TITLE
Chore: Mark all "not allowed" methods as deprecated

### DIFF
--- a/src/Forms/IconPicker.php
+++ b/src/Forms/IconPicker.php
@@ -164,12 +164,20 @@ class IconPicker extends Select
     }
 
     /**
+     * Marks the calling method as not allowed (whether because it's not supported or because it's meaningless when using this field)
+     * @throws \BadMethodCallException Always
+     */
+    protected function markAsNotAllowed(string $reason = 'Method not allowed.'): void {
+        throw new \BadMethodCallException($reason);
+    }
+
+    /**
      * @deprecated Method inherited from `\Filament\Forms\Components\Select` but not supported (or meaningless) when using this field
      * @throws \BadMethodCallException
      */
     public function relationship(string|Closure|null $name = null, string|Closure|null $titleAttribute = null, ?Closure $modifyQueryUsing = null, bool $ignoreRecord = false): static
     {
-        throw new \BadMethodCallException('Method not allowed.');
+        $this->markAsNotAllowed();
     }
 
     /**
@@ -178,7 +186,7 @@ class IconPicker extends Select
      */
     public function options(Arrayable|Closure|array|string|null $options): static
     {
-        throw new \BadMethodCallException('Method not allowed.');
+        $this->markAsNotAllowed();
     }
 
     /**
@@ -187,7 +195,7 @@ class IconPicker extends Select
      */
     public function allowHtml(bool|Closure $condition = true): static
     {
-        throw new \BadMethodCallException('Method not allowed.');
+        $this->markAsNotAllowed();
     }
 
     /**
@@ -196,7 +204,7 @@ class IconPicker extends Select
      */
     public function searchable(bool|array|Closure $condition = true): static
     {
-        throw new \BadMethodCallException('Method not allowed.');
+        $this->markAsNotAllowed();
     }
 
     /**
@@ -205,7 +213,7 @@ class IconPicker extends Select
      */
     public function getSearchResultsUsing(?Closure $callback): static
     {
-        throw new \BadMethodCallException('Method not allowed.');
+        $this->markAsNotAllowed();
     }
 
     /**
@@ -214,7 +222,7 @@ class IconPicker extends Select
      */
     public function getOptionLabelFromRecordUsing(?Closure $callback): static
     {
-        throw new \BadMethodCallException('Method not allowed.');
+        $this->markAsNotAllowed();
     }
 
     /**
@@ -223,7 +231,7 @@ class IconPicker extends Select
      */
     public function createOptionUsing(?Closure $callback): static
     {
-        throw new \BadMethodCallException('Method not allowed.');
+        $this->markAsNotAllowed();
     }
 
     /**
@@ -232,7 +240,7 @@ class IconPicker extends Select
      */
     public function createOptionAction(?Closure $callback): static
     {
-        throw new \BadMethodCallException('Method not allowed.');
+        $this->markAsNotAllowed();
     }
 
     /**
@@ -241,7 +249,7 @@ class IconPicker extends Select
      */
     public function createOptionForm(array|Closure|null $schema): static
     {
-        throw new \BadMethodCallException('Method not allowed.');
+        $this->markAsNotAllowed();
     }
 
     /**
@@ -250,7 +258,7 @@ class IconPicker extends Select
      */
     public function schema(array|Closure $components): static
     {
-        throw new \BadMethodCallException('Method not allowed.');
+        $this->markAsNotAllowed();
     }
 
     /**
@@ -259,7 +267,7 @@ class IconPicker extends Select
      */
     public function multiple(bool|Closure $condition = true): static
     {
-        throw new \BadMethodCallException('Method not allowed.');
+        $this->markAsNotAllowed();
     }
 
     private function loadIcons(): Collection

--- a/src/Forms/IconPicker.php
+++ b/src/Forms/IconPicker.php
@@ -163,56 +163,100 @@ class IconPicker extends Select
         return $results;
     }
 
+    /**
+     * @deprecated Method inherited from `\Filament\Forms\Components\Select` but not supported (or meaningless) when using this field
+     * @throws \BadMethodCallException
+     */
     public function relationship(string|Closure|null $name = null, string|Closure|null $titleAttribute = null, ?Closure $modifyQueryUsing = null, bool $ignoreRecord = false): static
     {
         throw new \BadMethodCallException('Method not allowed.');
     }
 
+    /**
+     * @deprecated Method inherited from `\Filament\Forms\Components\Select` but not supported (or meaningless) when using this field
+     * @throws \BadMethodCallException
+     */
     public function options(Arrayable|Closure|array|string|null $options): static
     {
         throw new \BadMethodCallException('Method not allowed.');
     }
 
+    /**
+     * @deprecated Method inherited from `\Filament\Forms\Components\Select` but not supported (or meaningless) when using this field
+     * @throws \BadMethodCallException
+     */
     public function allowHtml(bool|Closure $condition = true): static
     {
         throw new \BadMethodCallException('Method not allowed.');
     }
 
+    /**
+     * @deprecated Method inherited from `\Filament\Forms\Components\Select` but not supported (or meaningless) when using this field
+     * @throws \BadMethodCallException
+     */
     public function searchable(bool|array|Closure $condition = true): static
     {
         throw new \BadMethodCallException('Method not allowed.');
     }
 
+    /**
+     * @deprecated Method inherited from `\Filament\Forms\Components\Select` but not supported (or meaningless) when using this field
+     * @throws \BadMethodCallException
+     */
     public function getSearchResultsUsing(?Closure $callback): static
     {
         throw new \BadMethodCallException('Method not allowed.');
     }
 
+    /**
+     * @deprecated Method inherited from `\Filament\Forms\Components\Select` but not supported (or meaningless) when using this field
+     * @throws \BadMethodCallException
+     */
     public function getOptionLabelFromRecordUsing(?Closure $callback): static
     {
         throw new \BadMethodCallException('Method not allowed.');
     }
 
+    /**
+     * @deprecated Method inherited from `\Filament\Forms\Components\Select` but not supported (or meaningless) when using this field
+     * @throws \BadMethodCallException
+     */
     public function createOptionUsing(?Closure $callback): static
     {
         throw new \BadMethodCallException('Method not allowed.');
     }
 
+    /**
+     * @deprecated Method inherited from `\Filament\Forms\Components\Select` but not supported (or meaningless) when using this field
+     * @throws \BadMethodCallException
+     */
     public function createOptionAction(?Closure $callback): static
     {
         throw new \BadMethodCallException('Method not allowed.');
     }
 
+    /**
+     * @deprecated Method inherited from `\Filament\Forms\Components\Select` but not supported (or meaningless) when using this field
+     * @throws \BadMethodCallException
+     */
     public function createOptionForm(array|Closure|null $schema): static
     {
         throw new \BadMethodCallException('Method not allowed.');
     }
 
+    /**
+     * @deprecated Method inherited from `\Filament\Forms\Components\Select` but not supported (or meaningless) when using this field
+     * @throws \BadMethodCallException
+     */
     public function schema(array|Closure $components): static
     {
         throw new \BadMethodCallException('Method not allowed.');
     }
 
+    /**
+     * @deprecated Method inherited from `\Filament\Forms\Components\Select` but not supported (or meaningless) when using this field
+     * @throws \BadMethodCallException
+     */
     public function multiple(bool|Closure $condition = true): static
     {
         throw new \BadMethodCallException('Method not allowed.');


### PR DESCRIPTION
This PR marks all "not allowed" methods as deprecated, and adds the missing `@throws` PHPDoc tag.