### PR TITLE
fix: optimize CSS asset loading by using lazy loading

### DIFF
--- a/resources/views/forms/icon-picker.blade.php
+++ b/resources/views/forms/icon-picker.blade.php
@@ -1,5 +1,8 @@
 <div {{ $attributes->merge([
     'class' => "filament-icon-picker filament-icon-picker-{$getLayout()}",
-])->merge($getColumnsConfig()) }}>
+])->merge($getColumnsConfig()) }}
+x-data="{}"
+x-load-css="[@js(\Filament\Support\Facades\FilamentAsset::getStyleHref('filament-icon-picker-stylesheet', package: 'guava/filament-icon-picker'))]"
+>
 	@include('filament-forms::components.select')
 </div>

--- a/resources/views/tables/icon-column.blade.php
+++ b/resources/views/tables/icon-column.blade.php
@@ -1,4 +1,7 @@
-<div class="filament-icon-picker-icon-column px-4 py-3">
+<div class="filament-icon-picker-icon-column px-4 py-3"
+x-data="{}"
+x-load-css="[@js(\Filament\Support\Facades\FilamentAsset::getStyleHref('filament-icon-picker-stylesheet', package: 'guava/filament-icon-picker'))]"
+>
 	@if($icon = $getState())
 		<x-icon class="h-6" name="{{$icon}}" />
 	@endif

--- a/src/FilamentIconPickerServiceProvider.php
+++ b/src/FilamentIconPickerServiceProvider.php
@@ -23,7 +23,7 @@ class FilamentIconPickerServiceProvider extends PackageServiceProvider
         parent::bootingPackage();
 
         FilamentAsset::register([
-            Css::make('filament-icon-picker-stylesheet', __DIR__ . '/../dist/plugin.css'),
+            Css::make('filament-icon-picker-stylesheet', __DIR__ . '/../dist/plugin.css')->loadedOnRequest(),
         ], package: 'guava/filament-icon-picker');
     }
 


### PR DESCRIPTION
Changes:

1. Avoided conflicts with other parts of the project where Filament is loading assets. By using lazy loading, the CSS files are only loaded when necessary, ensuring there is no overlap or redundant loading across different sections of the application.
2. Removed unnecessary CSS loading from areas where it was not needed, based on best practices outlined in the Filament documentation on lazy loading CSS: [Lazy Loading Filament CSS](https://filamentphp.com/docs/3.x/support/assets#lazy-loading-css)