### PR TITLE
feature: add getOptionLabelUsing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,20 @@ IconPicker::make('icon')
     ->disallowIcons(['fas-user']);
 ```
 
+#### Custom Icon Option Label
+By default, the options display their labels using the icon's name. However, you can customize
+these labels to provide a more user-friendly or localized experience.
+
+```php
+// Customize the given icon label within a closure. Use translations __() if needed.
+IconPicker::make('icon')
+    ->getOptionLabelUsing(fn (string $icon) => match ($icon) {
+        'heroicon-o-user' => 'User',
+        'heroicon-o-tag' => 'Tag',
+        'chat-bubble-left' => 'Chat'
+        default => $icon
+    });
+```
 
 #### Layout
 The icon picker comes with two layouts. The default, `Layout::FLOATING` is the standard layout used in Filament Selects.  The search results will appear in a pop over window.

--- a/resources/views/item.blade.php
+++ b/resources/views/item.blade.php
@@ -9,6 +9,6 @@
 			{{-- Ugly fix for choices.js not registering clicks on SVGs. --}}
 			<div class="w-full h-full absolute z-10"></div>
 		</div>
-		<small class="w-full text-center grow-0 shrink-0 h-4 truncate">{{$icon}}</small>
+		<small class="w-full text-center grow-0 shrink-0 h-4 truncate">{{ $optionLabel ?? $icon }}</small>
 	</div>
 </div>

--- a/src/Forms/IconPicker.php
+++ b/src/Forms/IconPicker.php
@@ -50,24 +50,22 @@ class IconPicker extends Select
 
             return $this->tryCache($key, function () use ($component, $search, $icons) {
                 return collect($icons)
-                    ->filter(fn(string $icon) => str_contains($icon, $search))
+                    ->filter(fn(string $icon) => str_contains($icon, $search) || str_contains($this->getIconOptionLabel($icon), $search))
                     ->mapWithKeys(function (string $icon) use ($component) {
-                        return [$icon => $component->getItemTemplate(['icon' => $icon])];
+                        return [$icon => $component->getItemTemplate([
+                            'icon' => $icon,
+                            'optionLabel' => $this->getIconOptionLabel($icon)
+                        ])];
                     })
                     ->toArray();
             });
-        };
-
-        $this->getOptionLabelUsing = function (IconPicker $component, $value) {
-            if ($value) {
-                return $component->getItemTemplate(['icon' => $value]);
-            }
         };
 
         $this
             ->itemTemplate(function (IconPicker $component, string $icon) {
                 return \view('filament-icon-picker::item', [
                     'icon' => $icon,
+                    'optionLabel' => $this->getIconOptionLabel($icon)
                 ])->render();
             })
             ->placeholder(function () {
@@ -161,6 +159,14 @@ class IconPicker extends Select
         }
 
         return $results;
+    }
+
+    protected function getIconOptionLabel(string $icon): ?string
+    {
+        return $this->evaluate($this->getOptionLabelUsing, [
+            'icon' => $icon,
+            'value' => $icon
+        ]);
     }
 
     /**


### PR DESCRIPTION
This PR adds the ability to configure icon option labels using a closure via getOptionLabelUsing.

The primary reason behind this feature is to allow for a more user-friendly experience when selecting different icons. Regular users are unlikely to search for or recognize icons by their actual names. 

README.md has been updated to reflect this